### PR TITLE
Brackets keymap configuration for atom

### DIFF
--- a/keymap.cson
+++ b/keymap.cson
@@ -6,7 +6,7 @@
 # each selector can only be declared once.
 #
 # You can create a new keybinding in this file by typing "key" and then hitting
-# tab.
+# tab.key
 #
 # Here's an example taken from Atom's built-in keymap:
 #
@@ -14,8 +14,12 @@
 #   'enter': 'editor:newline'
 #
 # 'atom-workspace':
-#   'ctrl-shift-p': 'core:move-up'
-#   'ctrl-p': 'core:move-down'
+#   'ctrl-shift-p': 'core:move-up'987321`
+
+#   'ctrl-p': 'core:mut keymaps in these guides:
+# * https://atom.io/docs/latest/usiut keymaps in these guides:
+# * https://atom.io/docs/latest/usiut keymaps in these guides:
+# * https://atom.io/docs/latest/usiove-down'
 #
 # You can find more information about keymaps in these guides:
 # * https://atom.io/docs/latest/using-atom-basic-customization#customizing-key-bindings
@@ -26,20 +30,35 @@
 # Debugging Guide for more information:
 # * https://atom.io/docs/latest/hacking-atom-debugging#check-the-keybindings
 #
+#
 # This file uses CoffeeScript Object Notation (CSON).
 # If you are unfamiliar with CSON, you can read more about it in the
 # Atom Flight Manual:
-    # https://atom.io/docs/latest/using-atom-basic-customization#cson
-#'body':
+    # https://atom.io'ctrl-alt-b': 'find-and-repl'ctrl-alt-b': 'find-and-replace:select-undo'
+#'body':fold-at-indent-level-1'
 
 'atom-text-editor:not([mini])':
   'ctrl-shift-up': 'editor:move-line-up'
-  'ctrl-shift-down': 'editor:move-line-down'
-  'ctrl-up': 'unset!'
+  'ctrl-shift-b': 'find-and-replace:select-skip'
+  'alt-2': 'editor:fold-at-indent-level-2'
+  'ctrl-b': 'find-and-replace:select-next'
+  'alt-1': 'editor:fold-at-indent-level-1'
   'ctrl-down': 'unset!'
-  'alt-right': 'editor:move-to-end-of-screen-line'
+  'ctrl-alt-b': 'find-and-replace:select-undo'
+  'ctrl-up': 'unset!'
   'alt-left': 'editor:move-to-first-character-of-line'
+  'alt-3': 'editor:fold-at-indent-level-3'
+  'alt-right': 'editor:move-to-end-of-screen-line'
   'alt-shift-right': 'editor:select-to-end-of-line'
   'alt-shift-left': 'editor:select-to-first-character-of-line'
+  'ctrl-shift-down': 'editor:move-line-down'
+  'ctrl-alt-backspace': 'editor:delete-to-end-of-line'
   'ctrl-d': 'editor:duplicate-lines'
   'ctrl-shift-D': 'editor:delete-line'
+  'ctrl-shift-F': 'symbols-view:toggle-file-symbols'
+  'alt-j': 'symbols-view:go-to-declaration'
+  'ctrl-alt-j': 'symbols-view:return-from-declaration'
+  'ctrl-alt-h': 'tree-view:toggle'
+  'shift-alt-up': 'window:focus-pane-above'
+  'shift-alt-down': 'window:focus-pane-below'
+  'shift-alt-n': 'window:focus-next-pane'


### PR DESCRIPTION
Added a few more Brackets key bindings to be used with Atom

'atom-text-editor:not([mini])':
  'ctrl-shift-up': 'editor:move-line-up'
  'ctrl-shift-b': 'find-and-replace:select-skip'
  'alt-2': 'editor:fold-at-indent-level-2'
  'ctrl-b': 'find-and-replace:select-next'
  'alt-1': 'editor:fold-at-indent-level-1'
  'ctrl-down': 'unset!'
  'ctrl-alt-b': 'find-and-replace:select-undo'
  'ctrl-up': 'unset!'
  'alt-left': 'editor:move-to-first-character-of-line'
  'alt-3': 'editor:fold-at-indent-level-3'
  'alt-right': 'editor:move-to-end-of-screen-line'
  'alt-shift-right': 'editor:select-to-end-of-line'
  'alt-shift-left': 'editor:select-to-first-character-of-line'
  'ctrl-shift-down': 'editor:move-line-down'
  'ctrl-alt-backspace': 'editor:delete-to-end-of-line'
  'ctrl-d': 'editor:duplicate-lines'
  'ctrl-shift-D': 'editor:delete-line'
  'ctrl-shift-F': 'symbols-view:toggle-file-symbols'
  'alt-j': 'symbols-view:go-to-declaration'
  'ctrl-alt-j': 'symbols-view:return-from-declaration'
  'ctrl-alt-h': 'tree-view:toggle'
  'shift-alt-up': 'window:focus-pane-above'
  'shift-alt-down': 'window:focus-pane-below'
  'shift-alt-n': 'window:focus-next-pane'